### PR TITLE
Fix DoubleSlider TypeError and scikit-image peak_local_max compatibility

### DIFF
--- a/deepd3/core/analysis.py
+++ b/deepd3/core/analysis.py
@@ -758,7 +758,10 @@ class ROI3D_Creator(QObject):
         if applyWatershed:
             D = distance_transform_edt(labels > 0)
             # Seed generation
-            localMax = peak_local_max(D, indices=False, min_distance=0, footprint=np.ones((3,3,3)), exclude_border=1)
+            coordinates = peak_local_max(D, min_distance=0, footprint=np.ones((3,3,3)), exclude_border=1)
+            localMax = np.zeros_like(D, dtype=bool)
+            if len(coordinates) > 0:
+                localMax[tuple(coordinates.T)] = True
 
             markers = labelImage(localMax, structure=np.ones((3,3,3)))[0]
 
@@ -860,7 +863,10 @@ class ROI2D_Creator(QObject):
 
             if applyWatershed:
                 D = cv2.distanceTransform(im, cv2.DIST_L2, maskSize)
-                Ma = peak_local_max(D, indices=False, footprint=np.ones((3,3)), min_distance=minDistance, labels=im)
+                coordinates = peak_local_max(D, footprint=np.ones((3,3)), min_distance=minDistance, labels=im)
+                Ma = np.zeros_like(D, dtype=bool)
+                if len(coordinates) > 0:
+                    Ma[tuple(coordinates.T)] = True
                 foreground_labels = cv2.connectedComponents(Ma.astype(np.uint8)*255)[1]
 
                 labels = watershed(-D, foreground_labels, mask=im)

--- a/deepd3/inference/gui.py
+++ b/deepd3/inference/gui.py
@@ -476,13 +476,13 @@ class DoubleSlider(QSlider):
         return float(super(DoubleSlider, self).value()) / self._multi
 
     def setMinimum(self, value):
-        return super(DoubleSlider, self).setMinimum(value * self._multi)
+        return super(DoubleSlider, self).setMinimum(int(value * self._multi))
 
     def setMaximum(self, value):
-        return super(DoubleSlider, self).setMaximum(value * self._multi)
+        return super(DoubleSlider, self).setMaximum(int(value * self._multi))
 
     def setSingleStep(self, value):
-        return super(DoubleSlider, self).setSingleStep(value * self._multi)
+        return super(DoubleSlider, self).setSingleStep(int(value * self._multi))
 
     def singleStep(self):
         return float(super(DoubleSlider, self).singleStep()) / self._multi


### PR DESCRIPTION
- Add int() casting to DoubleSlider setMinimum, setMaximum, setSingleStep methods to fix TypeError with PyQt5
- Update peak_local_max calls to use new scikit-image API returning coordinates instead of boolean mask