### PR TITLE
Fix NameError in ExportFolder.export progress signal

### DIFF
--- a/deepd3/core/export.py
+++ b/deepd3/core/export.py
@@ -47,7 +47,7 @@ class ExportFolder(QObject):
                 df.to_csv(os.path.join(subtarget, str(i['ROI_id'])+".csv"), index=False)
 
             # Tell GUI that there's some progress
-            self.zSignal.emit(int(z), len(self.rois.keys()))
+            self.zSignal.emit(int(k), len(self.rois.keys()))
 
 
 class ExportImageJ(QObject):


### PR DESCRIPTION
In deepd3/core/export.py, ExportFolder.export() iterates over self.rois using for k, v in self.rois.items(), but emits the progress signal using int(z), where z is undefined:
```python
self.zSignal.emit(int(z), len(self.rois.keys()))
```
This raises NameError: name 'z' is not defined on the first iteration. As a result, "Export ROIs to folder" only writes the first z-plane's ROIs instead of all planes.

This PR replaces z with k:
```python
self.zSignal.emit(int(k), len(self.rois.keys()))
```
Tested locally (Python 3.9): after the change, "Export ROIs to folder" produces one folder per z-plane for the full stack.